### PR TITLE
Use UID variable from environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       args:
         user: sammy
-        uid: 1000
+        uid: ${UID:-1000}
       context: ./
     image: minicli-php8-dev
     restart: unless-stopped


### PR DESCRIPTION
This PR changes `docker-compose.yml` to use `$UID` environment variable instead of hardcoded `1000` to avoid users permissions errors.

Some distros, by default, create the first user with UID (user id) equals to `1000`; if we create another user, this second will be `1001`. There's a variable that stores that number, but sometimes it is not available. So we use a variable expansion with default value.