### PR TITLE
Update sanbox minicli sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bash_history
 .viminfo
 vendor
+.composer

--- a/app/Command/Hello/DefaultController.php
+++ b/app/Command/Hello/DefaultController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Command\Hello;
+
+use Minicli\Command\CommandController;
+
+class DefaultController extends CommandController
+{
+    public function handle()
+    {       
+        $this->getPrinter()->display("Hello MiniCLI!");
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,10 @@
 {
     "require": {
         "minicli/minicli": "^2.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
     }
 }

--- a/minicli
+++ b/minicli
@@ -8,21 +8,11 @@ if (php_sapi_name() !== 'cli') {
 require __DIR__ . '/vendor/autoload.php';
 
 use Minicli\App;
-use Minicli\Command\CommandCall;
 
-$app = new App();
-
-$app->setSignature('./minicli debug');
-
-$app->registerCommand('debug', function(CommandCall $input) use($app) {
-    $printer = $app->getPrinter();
-    $printer->info("Minicli 2.0 Sandbox", true);
-    $printer->info("System info: PHP " . PHP_VERSION . PHP_EXTRA_VERSION);
-    $printer->success("Input info:");
-
-    var_dump($input);
-
-    $printer->display("Check https://docs.minicli.dev for documentation.");
-});
+$app = new App([
+    'app_path' => __DIR__.'/app/Command',
+    'theme' => '\Unicorn',
+    'debug' => false
+]);
 
 $app->runCommand($argv);


### PR DESCRIPTION
This PR modifies the current minicli app in the sandbox. As a new user of the tool, I felt that convert the current code into a more organized one (using command controllers) is a little tricky. For me, the controller approach seems to be more friendly to new users and makes easy to read not only the code but the project itself.

For that, I made some changes in the minicli script to map the commands created in the app folder and wrote a simple command to work as an example about how to start.